### PR TITLE
Allow all doctrine versions 2.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "doctrine/dbal": ">=2.2.3,<2.4-dev",
-        "herrera-io/date-interval": ">=1.1,<2.0-dev"
+        "doctrine/dbal": "~2.2,>=2.2.3",
+        "herrera-io/date-interval": "~1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",
-        "doctrine/orm": ">=2.2.3,<2.4-dev"
+        "doctrine/orm": "~2.2,>=2.2.3"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Also simplified version constrain for herrera-io/date-interval
